### PR TITLE
Create a WARNING activity log if an observation is filtered

### DIFF
--- a/app/webhooks/handlers.py
+++ b/app/webhooks/handlers.py
@@ -1,8 +1,9 @@
 import json
 import pyjq
 import logging
+from gundi_core.schemas.v2 import LogLevel
 from app.services.gundi import send_observations_to_gundi, send_events_to_gundi
-from app.services.activity_logger import webhook_activity_logger
+from app.services.activity_logger import webhook_activity_logger, log_webhook_activity
 from .core import GenericJsonPayload,  GenericJsonTransformConfig
 
 
@@ -24,7 +25,14 @@ async def webhook_handler(payload: GenericJsonPayload, integration=None, webhook
     # Check if a filter is present in the filtered data
     for data in transformed_data:
         if data.get("status", "OK") != 'OK':
-            logger.info(f"'{data}' point received was filtered")
+            logger.warning(f"'{data}' point received was filtered")
+            await log_webhook_activity(
+                integration_id=integration.id,
+                webhook_id=integration.webhook_configuration.id,
+                level=LogLevel.WARNING,
+                title="Invalid observation filtered",
+                data={"payload": input_data, "transformed_data": data}
+            )
             transformed_data.remove(data)
     if transformed_data:
         if webhook_config.output_type == "obv":  # ToDo: Use an enum?


### PR DESCRIPTION
### Relevant Link

https://allenai.atlassian.net/browse/GUNDI-4351

---

This pull request introduces changes to enhance logging in the `webhook_handler` function by adding a new activity logging mechanism and improving log granularity. It also includes an update to the imported modules to support these enhancements.

### Logging enhancements:

* [`app/webhooks/handlers.py`](diffhunk://#diff-9f1d5d62b1620953b12dee0238737bfc5db145f02243af179b2d34a812fd03e1L27-R35): Changed the log level for filtered data from `info` to `warning` to better reflect the significance of the event.
* [`app/webhooks/handlers.py`](diffhunk://#diff-9f1d5d62b1620953b12dee0238737bfc5db145f02243af179b2d34a812fd03e1L27-R35): Added a call to `log_webhook_activity` to log detailed information about filtered observations, including integration and webhook IDs, log level, title, and relevant data.

### Module updates:

* [`app/webhooks/handlers.py`](diffhunk://#diff-9f1d5d62b1620953b12dee0238737bfc5db145f02243af179b2d34a812fd03e1R4-R6): Added an import for `LogLevel` from `gundi_core.schemas.v2` and extended the import of `webhook_activity_logger` to include `log_webhook_activity` from `app.services.activity_logger`.