### PR TITLE
fix: retry transient anyio.EndOfStream when sending to Gundi (GUNDI-5423)

### DIFF
--- a/app/services/gundi.py
+++ b/app/services/gundi.py
@@ -1,11 +1,18 @@
 import datetime
 from typing import List
+import anyio
 import httpx
 import stamina
 from gundi_client_v2.client import GundiClient, GundiDataSenderClient
 
+# Transient transport failures worth retrying. anyio.EndOfStream shows up when a
+# connection (often the TLS handshake) is dropped mid-flight; httpcore 0.17.x
+# doesn't map it to httpx.ConnectError, so it would otherwise escape the
+# httpx.HTTPError retry net. See GUNDI-5423 (fix) and GUNDI-5424 (httpcore upgrade).
+RETRYABLE_SEND_ERRORS = (httpx.HTTPError, anyio.EndOfStream)
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+
+@stamina.retry(on=RETRYABLE_SEND_ERRORS, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def _get_gundi_api_key(integration_id):
     async with GundiClient() as gundi_client:
         return await gundi_client.get_integration_api_key(
@@ -22,7 +29,7 @@ async def _get_sensors_api_client(integration_id):
     return sensors_api_client
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(on=RETRYABLE_SEND_ERRORS, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     """
     Send Events to Gundi using the REST API v2
@@ -51,7 +58,7 @@ async def send_events_to_gundi(events: List[dict], **kwargs) -> dict:
     return await sensors_api_client.post_events(data=events)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(on=RETRYABLE_SEND_ERRORS, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple], **kwargs) -> dict:
     """
     Send Event Attachments to Gundi using the REST API v2
@@ -69,7 +76,7 @@ async def send_event_attachments_to_gundi(event_id: str, attachments: List[tuple
     return await sensors_api_client.post_event_attachments(event_id=event_id, attachments=attachments)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(on=RETRYABLE_SEND_ERRORS, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict:
     """
     Send Observations to Gundi using the REST API v2
@@ -99,7 +106,7 @@ async def send_observations_to_gundi(observations: List[dict], **kwargs) -> dict
     return await sensors_api_client.post_observations(data=observations)
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
+@stamina.retry(on=RETRYABLE_SEND_ERRORS, wait_initial=10.0, wait_jitter=10.0, wait_max=300.0)
 async def send_messages_to_gundi(messages: List[dict], **kwargs) -> dict:
     """
     Send Messages to Gundi using the REST API v2

--- a/app/services/tests/test_gundi_api.py
+++ b/app/services/tests/test_gundi_api.py
@@ -1,3 +1,4 @@
+import anyio
 import pytest
 from app.services.gundi import send_events_to_gundi, send_observations_to_gundi, send_event_attachments_to_gundi
 
@@ -121,3 +122,40 @@ async def test_send_observations_to_gundi(
     assert len(response) == 2
     assert mock_gundi_sensors_client_class.called
     mock_gundi_sensors_client_class.return_value.post_observations.assert_called_once_with(data=observations)
+
+
+@pytest.mark.asyncio
+async def test_send_observations_to_gundi_retries_on_end_of_stream(
+        mocker, mock_gundi_client_v2_class, mock_gundi_sensors_client_class,
+        mock_get_gundi_api_key, integration_v2, observations_created_response
+):
+    # Avoid real backoff waits during the retry
+    mocker.patch("asyncio.sleep", new_callable=mocker.AsyncMock)
+    mocker.patch("app.services.gundi.GundiClient", mock_gundi_client_v2_class)
+    mocker.patch("app.services.gundi.GundiDataSenderClient", mock_gundi_sensors_client_class)
+    mocker.patch("app.services.gundi._get_gundi_api_key", mock_get_gundi_api_key)
+    # The TLS handshake to the Sensors API occasionally drops mid-connection,
+    # surfacing as a bare anyio.EndOfStream (httpcore 0.17.3 doesn't map it to
+    # httpx.ConnectError). The send must retry through it, like any other
+    # transient transport failure.
+    mock_gundi_sensors_client_class.return_value.post_observations = mocker.AsyncMock(
+        side_effect=[anyio.EndOfStream(), observations_created_response]
+    )
+    observations = [
+        {
+            "source": "device-xy123",
+            "type": "tracking-device",
+            "subject_type": "puma",
+            "recorded_at": "2024-01-24 09:03:00-0300",
+            "location": {"lat": -51.748, "lon": -72.720},
+            "additional": {"speed_kmph": 5}
+        }
+    ]
+
+    response = await send_observations_to_gundi(
+        observations=observations,
+        integration_id=integration_v2.id
+    )
+
+    assert response == observations_created_response
+    assert mock_gundi_sensors_client_class.return_value.post_observations.call_count == 2


### PR DESCRIPTION
## Summary

Fixes intermittent production webhook delivery failures to the Gundi Sensors API (error group `CJyqx_fOp7egjAE`).

A connection dropped during the TLS handshake surfaces as a bare `anyio.EndOfStream`. The send helpers are wrapped in `@stamina.retry(on=httpx.HTTPError, ...)`, which is meant to absorb exactly this kind of transient failure — but the pinned `httpcore==0.17.3` does **not** map `anyio.EndOfStream` to `httpx.ConnectError` in `start_tls` (httpcore 1.0.x does). So the raw `anyio.EndOfStream` escapes the `httpx.HTTPError` retry net and the webhook fails on the first blip, even though the endpoint is healthy (same-batch sends succeed moments later).

## Change

Broaden the retry predicate to a shared `RETRYABLE_SEND_ERRORS = (httpx.HTTPError, anyio.EndOfStream)`, applied to all five `send_*`/`_get_gundi_api_key` helpers in `app/services/gundi.py`.

## Testing

- New regression test `test_send_observations_to_gundi_retries_on_end_of_stream` — written test-first, confirmed it failed before the fix (EndOfStream propagated, no retry), passes after.
- Full suite: **97 passed**.

## Follow-up

The proper upstream fix is to upgrade `httpcore`/`httpx` so transport errors map to `httpx.HTTPError` and this special-case can be dropped — tracked in **GUNDI-5424**.

Closes GUNDI-5423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)