### PR TITLE
fix: make dynamic-schema payload validation errors diagnosable

### DIFF
--- a/app/services/tests/test_webhooks.py
+++ b/app/services/tests/test_webhooks.py
@@ -67,6 +67,36 @@ async def test_process_webhook_request_with_dynamic_schema(
     )
 
 
+@pytest.mark.asyncio
+async def test_process_webhook_dynamic_schema_parse_error_is_diagnosable(
+        mocker, integration_v2_with_webhook_generic, mock_publish_event,
+        mock_get_webhook_handler_for_generic_json_payload, mock_webhook_handler,
+        mock_webhook_request_headers_onyesha
+):
+    mocker.patch("app.services.webhooks.get_webhook_handler", mock_get_webhook_handler_for_generic_json_payload)
+    mocker.patch("app.services.config_manager.IntegrationConfigurationManager.get_integration_details", AsyncMock(return_value=integration_v2_with_webhook_generic))
+    mocker.patch("app.services.webhooks.publish_event", mock_publish_event)
+    # `received_at` is typed as a string in the integration's json_schema; sending
+    # an object for it triggers exactly one validation error on the dynamic model.
+    bad_payload = {"received_at": {"unexpected": "object"}}
+
+    response = api_client.post(
+        "/webhooks",
+        headers=mock_webhook_request_headers_onyesha,
+        json=bad_payload,
+    )
+
+    assert response.status_code == 200
+    mock_publish_event.assert_called_once()
+    error = mock_publish_event.call_args.kwargs["event"].payload.error
+    # The error must identify which integration failed...
+    assert str(integration_v2_with_webhook_generic.id) in error
+    # ...name the offending field...
+    assert "received_at" in error
+    # ...and be a single greppable line (Cloud Run splits stdout on newlines).
+    assert "\n" not in error
+
+
 # TTL Configuration Tests
 
 @pytest.mark.asyncio

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -203,9 +203,11 @@ async def process_webhook(request: Request):
                 else:
                     parsed_payload = payload_model.parse_obj(json_content)
             except Exception as e:
+                webhook = getattr(integration.type, "webhook", None)
+                webhook_value = webhook.value if webhook else None
                 message = (
                     f"Error parsing payload for integration '{integration.id}' "
-                    f"(webhook '{integration.type.webhook.value}'): "
+                    f"(webhook '{webhook_value}'): "
                     f"{type(e).__name__}: {_summarize_payload_error(e)}. "
                     f"Please review configurations."
                 )
@@ -214,7 +216,7 @@ async def process_webhook(request: Request):
                     event=IntegrationWebhookFailed(
                         payload=WebhookExecutionFailed(
                             integration_id=str(integration.id),
-                            webhook_id=str(integration.type.webhook.value),
+                            webhook_id=str(webhook_value) if webhook_value is not None else None,
                             config_data=webhook_config_data,
                             error=message
                         )

--- a/app/services/webhooks.py
+++ b/app/services/webhooks.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 import httpx
 import stamina
 from fastapi import Request
+from pydantic import ValidationError
 from app import settings
 from app.services.activity_logger import log_activity, publish_event
 from gundi_client_v2 import GundiClient
@@ -19,6 +20,21 @@ from app.services.config_manager import IntegrationConfigurationManager
 config_manager = IntegrationConfigurationManager()
 logger = logging.getLogger(__name__)
 _diagnostic_client: httpx.AsyncClient | None = None
+
+
+def _summarize_payload_error(e: Exception) -> str:
+    """Render a payload parse error as a single, greppable line.
+
+    Pydantic ValidationErrors are multi-line by default, which Cloud Run splits
+    into separate log entries — losing the field detail from the summary line.
+    Flatten them to one line that names each offending field, message, and type.
+    """
+    if isinstance(e, ValidationError):
+        return "; ".join(
+            f"{'.'.join(str(loc) for loc in err['loc'])}: {err['msg']} ({err['type']})"
+            for err in e.errors()
+        )
+    return " ".join(str(e).split())
 
 
 def _get_diagnostic_client() -> httpx.AsyncClient:
@@ -187,7 +203,12 @@ async def process_webhook(request: Request):
                 else:
                     parsed_payload = payload_model.parse_obj(json_content)
             except Exception as e:
-                message = f"Error parsing payload: {type(e).__name__}: {str(e)}. Please review configurations."
+                message = (
+                    f"Error parsing payload for integration '{integration.id}' "
+                    f"(webhook '{integration.type.webhook.value}'): "
+                    f"{type(e).__name__}: {_summarize_payload_error(e)}. "
+                    f"Please review configurations."
+                )
                 logger.exception(message)
                 await publish_event(
                     event=IntegrationWebhookFailed(


### PR DESCRIPTION
## Summary

Recurring payload validation errors on the dynamic-schema path (`app/services/webhooks.py:186`, prod error group `CMa_6fnAtqWElwE`) were effectively unactionable. The log showed:

```
Error parsing payload: ValidationError: 1 validation error for DataSchema
```

…with **no integration id**, and — because Cloud Run splits stdout on newlines — only the first line of pydantic's multi-line error, so the **offending field name was dropped**. (`DataSchema` is just the default model name when the configured schema has no `title`, so it tells you nothing.)

This is **not a crash**: the payload simply doesn't conform to the integration's configured `json_schema`, and the code already catches it, publishes `IntegrationWebhookFailed`, and returns `{}`. The fix is purely about diagnosability.

## Change

Rebuild the parse-error message as a single, greppable line naming the integration id, webhook value, and flattened field detail. New `_summarize_payload_error()` helper flattens pydantic `ValidationError`s to `field: msg (type)` joined by `; ` (and collapses whitespace for any other exception). The same message rides on the published `IntegrationWebhookFailed` event.

Before:
```
Error parsing payload: ValidationError: 1 validation error for DataSchema
received_at
  str type expected (type=type_error.str). Please review configurations.
```
After (one line):
```
Error parsing payload for integration 'ed8ed116-…-0ecc4b0996a1' (webhook 'onyesha_wh_webhook'): ValidationError: received_at: str type expected (type_error.str). Please review configurations.
```

**No behavior change** — non-conforming payloads are still rejected exactly as before.

## Testing

- New `test_process_webhook_dynamic_schema_parse_error_is_diagnosable` — written test-first, confirmed it fails before the change (no integration id, multi-line) and passes after. It asserts the published error names the integration, names the offending field, and is a single line.
- Full suite: **98 passed**.

## Notes

- We deliberately do **not** log the raw payload (PII/size); the existing `diagnostic_destination_url` config remains the way to capture raw bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)